### PR TITLE
Include drivers/udp

### DIFF
--- a/drivers.autobuild
+++ b/drivers.autobuild
@@ -67,3 +67,5 @@ cmake_package "drivers/gnss_trimble"
 orogen_package "drivers/orogen/gnss_trimble"
 
 #orogen_package "drivers/orogen/autonav_interface" # not public
+
+cmake_package "drivers/udp"

--- a/source.yml
+++ b/source.yml
@@ -131,6 +131,10 @@ version_control:
     type: git
     url: https://github.com/rock-drivers/drivers-gnss_trimble.git
     branch: master
+  - drivers/udp:
+    type: git
+    url: https://github.com/esa-prl/drivers-udp.git
+    branch: master
   - perception/shutter_controller:
     type: git
     url: https://github.com/esa-prl/perception-shutter_controller.git


### PR DESCRIPTION
Include drivers/udp, package to create an udp bridge, used for simulations with Vortex Studio.