### PR TITLE
Add GA SLAM packages

### DIFF
--- a/control.autobuild
+++ b/control.autobuild
@@ -19,6 +19,10 @@ orogen_package "control/orogen/slippage_estimator"
 orogen_package "control/orogen/fdir"
 
 orogen_package "control/orogen/gps_heading"
+orogen_package "control/orogen/gps_transformer"
 
 orogen_package "control/orogen/pancam_panorama"
 orogen_package "control/orogen/pancam_360"
+orogen_package "control/orogen/pancam_transformer"
+
+orogen_package "control/orogen/orbiter_preprocessing"

--- a/manifests/slam/ga_slam.xml
+++ b/manifests/slam/ga_slam.xml
@@ -1,0 +1,8 @@
+<package>
+  <description brief="GA SLAM">
+  </description>
+  <author></author>
+  <license></license>
+  <url></url>
+  <rosdep name="external/grid_map_core" />
+</package>

--- a/manifests/slam/ga_slam_cereal.xml
+++ b/manifests/slam/ga_slam_cereal.xml
@@ -1,0 +1,8 @@
+<package>
+  <description brief="GA SLAM Cereal">
+  </description>
+  <author></author>
+  <license></license>
+  <url></url>
+  <rosdep name="external/grid_map_core" />
+</package>

--- a/rover.osdeps
+++ b/rover.osdeps
@@ -16,5 +16,5 @@ automake:
 libtool:
     debian, ubuntu: libtool
 
-ros-kinetic-grid-map-core:
+external/grid_map_core:
     debian, ubuntu: ros-kinetic-grid-map-core

--- a/rover.osdeps
+++ b/rover.osdeps
@@ -16,5 +16,28 @@ automake:
 libtool:
     debian, ubuntu: libtool
 
+# dependencies for ga_slam
 external/grid_map_core:
     debian, ubuntu: ros-kinetic-grid-map-core
+
+# dependencies for GA SLAM visualizations
+external/grid_map_msgs:
+    debian, ubuntu: ros-kinetic-grid-map-msgs
+
+external/grid_map_ros:
+    debian, ubuntu: ros-kinetic-grid-map-ros
+
+external/grid_map_visualization:
+    debian, ubuntu: ros-kinetic-grid-map-visualization
+
+external/grid_map_rviz_plugin:
+    debian, ubuntu: ros-kinetic-grid-map-rviz-plugin
+
+external/eigen_conversions:
+    debian, ubuntu: ros-kinetic-eigen-conversions
+
+external/tf_conversions:
+    debian, ubuntu: ros-kinetic-tf-conversions
+
+external/robot_state_publisher:
+    debian, ubuntu: ros-kinetic-robot-state-publisher

--- a/rover.osdeps
+++ b/rover.osdeps
@@ -15,3 +15,6 @@ automake:
 
 libtool:
     debian, ubuntu: libtool
+
+ros-kinetic-grid-map-core:
+    debian, ubuntu: ros-kinetic-grid-map-core

--- a/slam.autobuild
+++ b/slam.autobuild
@@ -3,6 +3,13 @@
 
 #cmake_package "slam/threed_odometry"
 #orogen_package "slam/orogen/threed_odometry"
+
 cmake_package "slam/ga_slam"
-cmake_package "slam/ga_slam_cereal"
 orogen_package "slam/orogen/ga_slam"
+
+cmake_package "slam/ga_slam_cereal" do |pkg|
+    puts pkg.srcdir.inspect
+    #run "export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/opt/ros/kinetic"
+    # puts File.join(pkg.srcdir,"/../grid_map/grid_map_core")
+    env_add 'CMAKE_PREFIX_PATH', "/opt/ros/kinetic"
+end

--- a/slam.autobuild
+++ b/slam.autobuild
@@ -5,8 +5,9 @@
 #orogen_package "slam/orogen/threed_odometry"
 
 cmake_package "slam/ga_slam"
+cmake_package "slam/ga_slam_cereal"
 orogen_package "slam/orogen/ga_slam"
 
-cmake_package "slam/ga_slam_cereal" do |pkg|
-    env_add 'CMAKE_PREFIX_PATH', "/opt/ros/kinetic"
-end
+# cmake_package "slam/ga_slam_cereal" do |pkg|
+#     env_add 'CMAKE_PREFIX_PATH', "/opt/ros/kinetic"
+# end

--- a/slam.autobuild
+++ b/slam.autobuild
@@ -8,8 +8,5 @@ cmake_package "slam/ga_slam"
 orogen_package "slam/orogen/ga_slam"
 
 cmake_package "slam/ga_slam_cereal" do |pkg|
-    puts pkg.srcdir.inspect
-    #run "export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/opt/ros/kinetic"
-    # puts File.join(pkg.srcdir,"/../grid_map/grid_map_core")
     env_add 'CMAKE_PREFIX_PATH', "/opt/ros/kinetic"
 end

--- a/slam.autobuild
+++ b/slam.autobuild
@@ -3,5 +3,6 @@
 
 #cmake_package "slam/threed_odometry"
 #orogen_package "slam/orogen/threed_odometry"
-#cmake_package "slam/ga_slam"
-#orogen_package "slam/orogen/ga_slam"
+cmake_package "slam/ga_slam"
+cmake_package "slam/ga_slam_cereal"
+orogen_package "slam/orogen/ga_slam"

--- a/source.yml
+++ b/source.yml
@@ -134,7 +134,7 @@ version_control:
   - control/orogen/orbiter_preprocessing:
     type: git
     url: https://github.com/esa-prl/control-orogen-orbiter_preprocessing
-    branch: master
+    branch: upgrade_pcl_to_1.8
   - drivers/orogen/gnss_trimble:
     type: git
     url: https://github.com/rock-drivers/drivers-orogen-gnss_trimble.git

--- a/source.yml
+++ b/source.yml
@@ -134,7 +134,7 @@ version_control:
   - control/orogen/orbiter_preprocessing:
     type: git
     url: https://github.com/esa-prl/control-orogen-orbiter_preprocessing
-    branch: upgrade_pcl_to_1.8
+    branch: master
   - drivers/orogen/gnss_trimble:
     type: git
     url: https://github.com/rock-drivers/drivers-orogen-gnss_trimble.git
@@ -206,7 +206,7 @@ version_control:
   - slam/ga_slam:
     type: git
     url: https://github.com/esa-prl/slam-ga_slam.git
-    branch: update_dependencies
+    branch: master
   - slam/ga_slam_cereal:
     type: git
     url: https://github.com/esa-prl/slam-ga_slam_cereal

--- a/source.yml
+++ b/source.yml
@@ -75,6 +75,10 @@ version_control:
     type: git
     url: https://github.com/esa-prl/control-orogen-pancam_360.git
     branch: RemoteOperations
+  - control/orogen/pancam_transformer:
+    type: git
+    url: https://github.com/esa-prl/control-orogen-pancam_transformer
+    branch: master
   - control/generic_rover_manoeuvre:
     type: git
     url: https://github.com/esa-prl/control-generic_rover_manoeuvre.git
@@ -115,6 +119,10 @@ version_control:
     type: git
     url: https://github.com/esa-prl/control-orogen-gps_heading.git
     branch: master
+  - control/orogen/gps_transformer:
+    type: git
+    url: https://github.com/esa-prl/control-orogen-gps_transformer
+    branch: master
   - control/orogen/slippage_estimator:
     type: git
     url: https://github.com/esa-prl/control-orogen-slippage_estimator.git
@@ -122,6 +130,10 @@ version_control:
   - control/orogen/fdir:
     type: git
     url: https://github.com/esa-prl/control-orogen-fdir.git
+    branch: master
+  - control/orogen/orbiter_preprocessing:
+    type: git
+    url: https://github.com/esa-prl/control-orogen-orbiter_preprocessing
     branch: master
   - drivers/orogen/gnss_trimble:
     type: git

--- a/source.yml
+++ b/source.yml
@@ -207,6 +207,10 @@ version_control:
     type: git
     url: https://github.com/esa-prl/slam-ga_slam.git
     branch: master
+  - slam/ga_slam_cereal:
+    type: git
+    url: https://github.com/esa-prl/slam-ga_slam_cereal
+    branch: master
   - slam/orogen/ga_slam:
     type: git
     url: https://github.com/esa-prl/slam-orogen-ga_slam.git

--- a/source.yml
+++ b/source.yml
@@ -206,7 +206,7 @@ version_control:
   - slam/ga_slam:
     type: git
     url: https://github.com/esa-prl/slam-ga_slam.git
-    branch: master
+    branch: update_dependencies
   - slam/ga_slam_cereal:
     type: git
     url: https://github.com/esa-prl/slam-ga_slam_cereal
@@ -214,7 +214,7 @@ version_control:
   - slam/orogen/ga_slam:
     type: git
     url: https://github.com/esa-prl/slam-orogen-ga_slam.git
-    branch: master
+    branch: add_dependencies
   - perception/traversability:
     type: git
     url: https://github.com/esa-prl/perception-traversability.git


### PR DESCRIPTION
The SLAM packages build properly in our docker images (tried up to `slam/orogen/ga_slam`). Please check whether they are working as expected. We can then also tend to the related pull requests (dependency version bumps):

https://github.com/esa-prl/slam-ga_slam/pull/1
https://github.com/esa-prl/control-orogen-orbiter_preprocessing/pull/1