### PR TITLE
Add dependencies for tools-pocolog_pybind

### DIFF
--- a/external.autobuild
+++ b/external.autobuild
@@ -1,0 +1,1 @@
+cmake_package 'external/pybind11'

--- a/rover.osdeps
+++ b/rover.osdeps
@@ -16,7 +16,7 @@ automake:
 libtool:
     debian, ubuntu: libtool
 
-# python3 os dependencies
+# python3 os dependencies for python bindings of various rock libraries
 # this currently installs python 3.6.* on Ubuntu 18.04
 python3:
     debian,ubuntu: python3-dev
@@ -49,6 +49,10 @@ python3-setuptools:
 cython3:
     debian, ubuntu: cython3
     opensuse: python3-Cython
+
+# pybind11 requires ninja-build
+ninja-build:
+    debian, ubuntu: ninja-build
 
 
 # dependencies for ga_slam

--- a/rover.osdeps
+++ b/rover.osdeps
@@ -16,6 +16,41 @@ automake:
 libtool:
     debian, ubuntu: libtool
 
+# python3 os dependencies
+# this currently installs python 3.6.* on Ubuntu 18.04
+python3:
+    debian,ubuntu: python3-dev
+    opensuse: python3-devel
+
+python3-pip:
+    debian,ubuntu: python3-pip
+    opensuse: python3-pip
+
+python3-nose:
+    debian,ubuntu: python3-nose
+    opensuse: python3-nose
+
+python3-pexpect:
+    debian,ubuntu: python3-pexpect
+    opensuse: python3-pexpect
+
+python3-msgpack:
+    debian,ubuntu: python3-msgpack
+    opensuse: python3-msgpack
+
+python3-distutils:
+    debian,ubuntu: python3-distutils
+    opensuse: python3-distutils-extra
+
+python3-setuptools:
+    debian,ubuntu: python3-setuptools
+    opensuse: python3-setuptools
+
+cython3:
+    debian, ubuntu: cython3
+    opensuse: python3-Cython
+
+
 # dependencies for ga_slam
 external/grid_map_core:
     debian, ubuntu: ros-kinetic-grid-map-core

--- a/source.yml
+++ b/source.yml
@@ -140,7 +140,9 @@ version_control:
     url: https://github.com/rock-drivers/drivers-gnss_trimble.git
     branch: master
   - external/pybind11:
-    github: pybind/pybind11
+    type: git
+    url: https://github.com/pybind/pybind11.git
+    branch: master
   - perception/shutter_controller:
     type: git
     url: https://github.com/esa-prl/perception-shutter_controller.git

--- a/source.yml
+++ b/source.yml
@@ -139,6 +139,8 @@ version_control:
     type: git
     url: https://github.com/rock-drivers/drivers-gnss_trimble.git
     branch: master
+  - external/pybind11:
+    github: pybind/pybind11
   - perception/shutter_controller:
     type: git
     url: https://github.com/esa-prl/perception-shutter_controller.git
@@ -243,8 +245,10 @@ version_control:
     #  type: git
     #  url: https://github.com/esa-prl/perception-orogen-spartan.git
     #  branch: master
-  - external/pybind11:
-    github: pybind/pybind11
+  - tools/pocolog_pybind:
+    type: git
+    url: https://github.com/esa-prl/tools-pocolog_pybind.git
+    branch: main
 
 # The following section defines overrides of this package set to packages defined in PRECEEDING package sets.
 # Precedence is given by the order they are stated in the manifest.

--- a/source.yml
+++ b/source.yml
@@ -243,6 +243,8 @@ version_control:
     #  type: git
     #  url: https://github.com/esa-prl/perception-orogen-spartan.git
     #  branch: master
+  - external/pybind11:
+    github: pybind/pybind11
 
 # The following section defines overrides of this package set to packages defined in PRECEEDING package sets.
 # Precedence is given by the order they are stated in the manifest.

--- a/tools.autobuild
+++ b/tools.autobuild
@@ -1,0 +1,1 @@
+cmake_package 'tools/pocolog_pybind'


### PR DESCRIPTION
- Add pybind11 as external/pybind
- Pybind requires ninja-build
- Activate python3 installations deactivated in rock-core package set
- Add `tools/pocolog_pybind` component

@levingerdes I will remove the wrong commit authors with a squash merge at the end